### PR TITLE
Check CHOLMOD index compatibility with SuiteSparse_long [OC-310]

### DIFF
--- a/Eigen/src/CholmodSupport/CholmodSupport.h
+++ b/Eigen/src/CholmodSupport/CholmodSupport.h
@@ -84,7 +84,7 @@ cholmod_sparse viewAsCholmod(Ref<SparseMatrix<_Scalar,_Options,_StorageIndex> > 
   {
     res.itype = CHOLMOD_INT;
   }
-  else if (internal::is_same<_StorageIndex,long>::value)
+  else if (internal::is_same<_StorageIndex,SuiteSparse_long>::value)
   {
     res.itype = CHOLMOD_LONG;
   }


### PR DESCRIPTION
This caused issues on Macintosh builds where the index type is somehow `long long` (still 64 bits), which causes an assertion in `viewAsCholmod()`.

Note that this change already exists in 3.4 upstream.