### PR TITLE
Implement MODULE

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "eigen",
+    hdrs = glob(["Eigen/**"]),
+    defines = [
+        "EIGEN_NO_DEBUG",
+    ] + select({
+        "@rules_swiftnav//third_party:intel_mkl": ["EIGEN_USE_MKL_ALL"],
+        "@rules_swiftnav//third_party:_enable_mkl": ["EIGEN_USE_MKL_ALL"],
+        "//conditions:default": [],
+    }),
+    includes = ["."],
+    deps = select({
+        "@rules_swiftnav//third_party:intel_mkl": ["@mkl"],
+        "@rules_swiftnav//third_party:_enable_mkl": ["@mkl"],
+        "//conditions:default": [],
+    }),
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "eigen",
+    version = "3.3.swiftnav",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_swiftnav", version = "0.1.0")


### PR DESCRIPTION
Implement `MODULE` for eigen, because a simple `BUILD` file as already implemented in `rules_swiftnav` is no longer sufficient.

Tested in https://github.com/swift-nav/starling-core/pull/1031