### PR TITLE
Properly model MKL deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,9 +1,15 @@
 module(
     name = "eigen",
-    version = "3.3.swiftnav",
+    version = "3.3.1.swiftnav",
     compatibility_level = 1,
 )
 
+bazel_dep(name = "platforms", version = "0.0.9")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_swiftnav", version = "0.1.0")
+
+# Use repo extension to provide MKL dependencies via http_archive
+mkl_ext = use_extension("//extensions:mkl_extension.bzl", "mkl_extension")
+use_repo(mkl_ext, "mkl", "mkl_headers")
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,20 @@
+workspace(name = "eigen")
+
+http_archive(
+    name = "mkl_headers",
+    build_file = "@rules_swiftnav//third_party:mkl_headers.BUILD",
+    sha256 = "b24d12a8e18ba23de5c659a33fb184a7ac6019d4b159e78f628d7c8de225f77a",
+    urls = [
+        "https://swiftnav-public-mkl-sharedlibs.s3.us-west-2.amazonaws.com/mkl-include-2023.1.0-intel_46342.tar.bz2",
+    ],
+)
+
+http_archive(
+    name = "mkl",
+    build_file = "@rules_swiftnav//third_party:mkl.BUILD",
+    sha256 = "c63adbfdbdc7c4992384a2d89cd62211e4a9f8061e3e841af1a269699531cb02",
+    strip_prefix = "lib",
+    urls = [
+        "https://swiftnav-public-mkl-sharedlibs.s3.us-west-2.amazonaws.com/mkl-static-2023.1.0-intel_46342.tar.bz2",
+    ],
+)

--- a/extensions/mkl_extension.bzl
+++ b/extensions/mkl_extension.bzl
@@ -1,0 +1,29 @@
+"""Repository extension for providing MKL dependencies via http_archive."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def _mkl_extension_impl(module_ctx):
+    """Implementation of the MKL extension."""
+    
+    # Define MKL headers
+    http_archive(
+        name = "mkl_headers",
+        build_file = "@rules_swiftnav//third_party:mkl_headers.BUILD",
+        sha256 = "b24d12a8e18ba23de5c659a33fb184a7ac6019d4b159e78f628d7c8de225f77a",
+        urls = [
+            "https://swiftnav-public-mkl-sharedlibs.s3.us-west-2.amazonaws.com/mkl-include-2023.1.0-intel_46342.tar.bz2",
+        ],
+    )
+    
+    # Define MKL static libraries
+    http_archive(
+        name = "mkl",
+        build_file = "@rules_swiftnav//third_party:mkl.BUILD",
+        sha256 = "c63adbfdbdc7c4992384a2d89cd62211e4a9f8061e3e841af1a269699531cb02",
+        strip_prefix = "lib",
+        urls = [
+            "https://swiftnav-public-mkl-sharedlibs.s3.us-west-2.amazonaws.com/mkl-static-2023.1.0-intel_46342.tar.bz2",
+        ],
+    )
+
+mkl_extension = module_extension(implementation = _mkl_extension_impl)


### PR DESCRIPTION
Implement the module extensions, which provide the `MKL` dependencies.