### PR TITLE
Revert Backport bug #1573: add noexcept move constructor and move assignment operator to Quaternion

### DIFF
--- a/Eigen/src/Geometry/Quaternion.h
+++ b/Eigen/src/Geometry/Quaternion.h
@@ -100,22 +100,6 @@ class QuaternionBase : public RotationBase<Derived, 3>
   EIGEN_DEVICE_FUNC Derived& operator=(const AngleAxisType& aa);
   template<class OtherDerived> EIGEN_DEVICE_FUNC Derived& operator=(const MatrixBase<OtherDerived>& m);
 
-#if EIGEN_HAS_RVALUE_REFERENCES
-  // Because we have a user-defined copy assignment operator, we don't get an implicit move constructor or assignment operator.
-  /** Default move constructor */
-  EIGEN_DEVICE_FUNC inline QuaternionBase(QuaternionBase&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_constructible<Scalar>::value) = default;
-
-  /** Default move assignment operator */
-  EIGEN_DEVICE_FUNC QuaternionBase& operator=(QuaternionBase&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_assignable<Scalar>::value) = default;
-
-  // And now because we declared a constructor, we don't get a default constructor or copy constructor. Say we want them.
-  /** Default constructor */
-  EIGEN_DEVICE_FUNC QuaternionBase() = default;
-
-  /** Copy constructor */
-  EIGEN_DEVICE_FUNC QuaternionBase(const QuaternionBase& other) = default;
-#endif
-
   /** \returns a quaternion representing an identity rotation
     * \sa MatrixBase::Identity()
     */
@@ -286,19 +270,6 @@ public:
   template<typename OtherScalar, int OtherOptions>
   EIGEN_DEVICE_FUNC explicit inline Quaternion(const Quaternion<OtherScalar, OtherOptions>& other)
   { m_coeffs = other.coeffs().template cast<Scalar>(); }
-
-#if EIGEN_HAS_RVALUE_REFERENCES
-  // We define a copy constructor, which means we don't get an implicit move constructor or assignment operator.
-  /** Default move constructor */
-  EIGEN_DEVICE_FUNC inline Quaternion(Quaternion&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_constructible<Scalar>::value) = default;
-
-  /** Default move assignment operator */
-  EIGEN_DEVICE_FUNC Quaternion& operator=(Quaternion&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_assignable<Scalar>::value) = default;
-
-  // And now because we declared a constructor, we don't get an implicit copy constructor. Say we want one.
-  /** Default copy constructor */
-  EIGEN_DEVICE_FUNC Quaternion(const Quaternion& other) = default;
-#endif
 
   EIGEN_DEVICE_FUNC static Quaternion UnitRandom();
 

--- a/Eigen/src/Geometry/Quaternion.h
+++ b/Eigen/src/Geometry/Quaternion.h
@@ -100,6 +100,22 @@ class QuaternionBase : public RotationBase<Derived, 3>
   EIGEN_DEVICE_FUNC Derived& operator=(const AngleAxisType& aa);
   template<class OtherDerived> EIGEN_DEVICE_FUNC Derived& operator=(const MatrixBase<OtherDerived>& m);
 
+#if EIGEN_HAS_RVALUE_REFERENCES
+  // Because we have a user-defined copy assignment operator, we don't get an implicit move constructor or assignment operator.
+  /** Default move constructor */
+  EIGEN_DEVICE_FUNC inline QuaternionBase(QuaternionBase&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_constructible<Scalar>::value) = default;
+
+  /** Default move assignment operator */
+  EIGEN_DEVICE_FUNC QuaternionBase& operator=(QuaternionBase&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_assignable<Scalar>::value) = default;
+
+  // And now because we declared a constructor, we don't get a default constructor or copy constructor. Say we want them.
+  /** Default constructor */
+  EIGEN_DEVICE_FUNC QuaternionBase() = default;
+
+  /** Copy constructor */
+  EIGEN_DEVICE_FUNC QuaternionBase(const QuaternionBase& other) = default;
+#endif
+
   /** \returns a quaternion representing an identity rotation
     * \sa MatrixBase::Identity()
     */
@@ -274,24 +290,14 @@ public:
 #if EIGEN_HAS_RVALUE_REFERENCES
   // We define a copy constructor, which means we don't get an implicit move constructor or assignment operator.
   /** Default move constructor */
-  EIGEN_DEVICE_FUNC inline Quaternion(Quaternion&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_constructible<Scalar>::value)
-  {
-    m_coeffs(std::move(other.coeffs()));
-  }
+  EIGEN_DEVICE_FUNC inline Quaternion(Quaternion&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_constructible<Scalar>::value) = default;
 
   /** Default move assignment operator */
-  EIGEN_DEVICE_FUNC Quaternion& operator=(Quaternion&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_assignable<Scalar>::value)
-  {
-    m_coeffs = std::move(other.coeffs());
-    return *this;
-  }
+  EIGEN_DEVICE_FUNC Quaternion& operator=(Quaternion&& other) EIGEN_NOEXCEPT_IF(std::is_nothrow_move_assignable<Scalar>::value) = default;
 
   // And now because we declared a constructor, we don't get an implicit copy constructor. Say we want one.
   /** Default copy constructor */
-  EIGEN_DEVICE_FUNC Quaternion(const Quaternion& other)
-  {
-    m_coeffs = other.coeffs();
-  }
+  EIGEN_DEVICE_FUNC Quaternion(const Quaternion& other) = default;
 #endif
 
   EIGEN_DEVICE_FUNC static Quaternion UnitRandom();
@@ -646,7 +652,7 @@ EIGEN_DEVICE_FUNC Quaternion<Scalar,Options> Quaternion<Scalar,Options>::UnitRan
   const Scalar u1 = internal::random<Scalar>(0, 1),
                u2 = internal::random<Scalar>(0, 2*EIGEN_PI),
                u3 = internal::random<Scalar>(0, 2*EIGEN_PI);
-  const Scalar a = sqrt(Scalar(1) - u1),
+  const Scalar a = sqrt(1 - u1),
                b = sqrt(u1);
   return Quaternion (a * sin(u2), a * cos(u2), b * sin(u3), b * cos(u3));
 }

--- a/test/geo_quaternion.cpp
+++ b/test/geo_quaternion.cpp
@@ -12,7 +12,6 @@
 #include <Eigen/Geometry>
 #include <Eigen/LU>
 #include <Eigen/SVD>
-#include "AnnoyingScalar.h"
 
 template<typename T> T bounded_acos(T v)
 {
@@ -86,7 +85,7 @@ template<typename Scalar, int Options> void quaternion(void)
   if (refangle>Scalar(EIGEN_PI))
     refangle = Scalar(2)*Scalar(EIGEN_PI) - refangle;
 
-  if((q1.coeffs()-q2.coeffs()).norm() > Scalar(10)*largeEps)
+  if((q1.coeffs()-q2.coeffs()).norm() > 10*largeEps)
   {
     VERIFY_IS_MUCH_SMALLER_THAN(abs(q1.angularDistance(q2) - refangle), Scalar(1));
   }
@@ -114,7 +113,7 @@ template<typename Scalar, int Options> void quaternion(void)
 
   // Do not execute the test if the rotation angle is almost zero, or
   // the rotation axis and v1 are almost parallel.
-  if (abs(aa.angle()) > Scalar(5)*test_precision<Scalar>()
+  if (abs(aa.angle()) > 5*test_precision<Scalar>()
       && (aa.axis() - v1.normalized()).norm() < Scalar(1.99)
       && (aa.axis() + v1.normalized()).norm() < Scalar(1.99))
   {
@@ -273,36 +272,18 @@ template<typename PlainObjectType> void check_const_correctness(const PlainObjec
   VERIFY( !(Map<ConstPlainObjectType, Aligned>::Flags & LvalueBit) );
 }
 
-#if EIGEN_HAS_RVALUE_REFERENCES
-
-// Regression for bug 1573
-struct MovableClass {
-  MovableClass() = default;
-  MovableClass(const MovableClass&) = default;
-  MovableClass(MovableClass&&) noexcept = default;
-  MovableClass& operator=(const MovableClass&) = default;
-  MovableClass& operator=(MovableClass&&) = default;
-  Quaternionf m_quat;
-};
-
-#endif
-
-EIGEN_DECLARE_TEST(geo_quaternion)
+void test_geo_quaternion()
 {
   for(int i = 0; i < g_repeat; i++) {
     CALL_SUBTEST_1(( quaternion<float,AutoAlign>() ));
     CALL_SUBTEST_1( check_const_correctness(Quaternionf()) );
-    CALL_SUBTEST_1(( quaternion<float,DontAlign>() ));
-    CALL_SUBTEST_1(( quaternionAlignment<float>() ));
-    CALL_SUBTEST_1( mapQuaternion<float>() );
-
     CALL_SUBTEST_2(( quaternion<double,AutoAlign>() ));
     CALL_SUBTEST_2( check_const_correctness(Quaterniond()) );
-    CALL_SUBTEST_2(( quaternion<double,DontAlign>() ));
-    CALL_SUBTEST_2(( quaternionAlignment<double>() ));
+    CALL_SUBTEST_3(( quaternion<float,DontAlign>() ));
+    CALL_SUBTEST_4(( quaternion<double,DontAlign>() ));
+    CALL_SUBTEST_5(( quaternionAlignment<float>() ));
+    CALL_SUBTEST_6(( quaternionAlignment<double>() ));
+    CALL_SUBTEST_1( mapQuaternion<float>() );
     CALL_SUBTEST_2( mapQuaternion<double>() );
-
-    AnnoyingScalar::dont_throw = true;
-    CALL_SUBTEST_3(( quaternion<AnnoyingScalar,AutoAlign>() ));
   }
 }

--- a/test/geo_quaternion.cpp
+++ b/test/geo_quaternion.cpp
@@ -277,8 +277,6 @@ template<typename PlainObjectType> void check_const_correctness(const PlainObjec
 
 // Regression for bug 1573
 struct MovableClass {
-  // The following line is a workaround for gcc 4.7 and 4.8 (see bug 1573 comments).
-  static_assert(std::is_nothrow_move_constructible<Quaternionf>::value,"");
   MovableClass() = default;
   MovableClass(const MovableClass&) = default;
   MovableClass(MovableClass&&) noexcept = default;


### PR DESCRIPTION
Revert PR #7 