### PR TITLE
Build with llvm20 [OI-3403]

### DIFF
--- a/Eigen/src/Core/functors/StlFunctors.h
+++ b/Eigen/src/Core/functors/StlFunctors.h
@@ -83,13 +83,17 @@ struct functor_traits<std::binder1st<T> >
 { enum { Cost = functor_traits<T>::Cost, PacketAccess = false }; };
 #endif
 
+#if (__cplusplus < 201703L) && (EIGEN_COMP_MSVC < 1910)
+// std::unary_negate is deprecated since c++17 and will be removed in c++20
 template<typename T>
 struct functor_traits<std::unary_negate<T> >
 { enum { Cost = 1 + functor_traits<T>::Cost, PacketAccess = false }; };
 
+// std::binary_negate is deprecated since c++17 and will be removed in c++20
 template<typename T>
 struct functor_traits<std::binary_negate<T> >
 { enum { Cost = 1 + functor_traits<T>::Cost, PacketAccess = false }; };
+#endif
 
 #ifdef EIGEN_STDEXT_SUPPORT
 

--- a/Eigen/src/Core/util/Macros.h
+++ b/Eigen/src/Core/util/Macros.h
@@ -388,11 +388,21 @@
 #endif
 
 // Does the compiler support result_of?
+// result_of was deprecated in c++17 and removed in c++ 20
 #ifndef EIGEN_HAS_STD_RESULT_OF
-#if EIGEN_MAX_CPP_VER>=11 && ((__has_feature(cxx_lambdas) || (defined(__cplusplus) && __cplusplus >= 201103L)))
+#if EIGEN_MAX_CPP_VER >= 11 &&                          \
+(defined(__cplusplus) && __cplusplus >= 201103L && __cplusplus < 201703L)
 #define EIGEN_HAS_STD_RESULT_OF 1
 #else
 #define EIGEN_HAS_STD_RESULT_OF 0
+#endif
+#endif
+
+#ifndef EIGEN_HAS_STD_INVOKE_RESULT
+#if EIGEN_MAX_CPP_VER >= 17 && (defined(__cplusplus) && __cplusplus >= 201703L)
+#define EIGEN_HAS_STD_INVOKE_RESULT 1
+#else
+#define EIGEN_HAS_STD_INVOKE_RESULT 0
 #endif
 #endif
 
@@ -607,8 +617,8 @@
 #define EIGEN_UNUSED
 #endif
 
-// Suppresses 'unused variable' warnings.
-namespace Eigen {
+    // Suppresses 'unused variable' warnings.
+    namespace Eigen {
   namespace internal {
     template<typename T> EIGEN_DEVICE_FUNC void ignore_unused_variable(const T&) {}
   }

--- a/Eigen/src/Core/util/Meta.h
+++ b/Eigen/src/Core/util/Meta.h
@@ -279,13 +279,30 @@ protected:
 };
 
 /** \internal
-  * Convenient struct to get the result type of a unary or binary functor.
+  * Convenient struct to get the result type of a nullary, unary, binary, or
+  * ternary functor.
   *
-  * It supports both the current STL mechanism (using the result_type member) as well as
-  * upcoming next STL generation (using a templated result member).
-  * If none of these members is provided, then the type of the first argument is returned. FIXME, that behavior is a pretty bad hack.
+  * Pre C++11:
+  * Supports both a Func::result_type member and templated
+  * Func::result<Func(ArgTypes...)>::type member.
+  *
+  * If none of these members is provided, then the type of the first
+  * argument is returned.
+  *
+  * Post C++11:
+  * This uses std::result_of. However, note the `type` member removes
+  * const and converts references/pointers to their corresponding value type.
   */
-#if EIGEN_HAS_STD_RESULT_OF
+#if EIGEN_HAS_STD_INVOKE_RESULT
+template <typename T>
+struct result_of;
+
+template <typename F, typename... ArgTypes>
+struct result_of<F(ArgTypes...)> {
+  typedef typename std::invoke_result<F, ArgTypes...>::type type1;
+  typedef typename remove_all<type1>::type type;
+};
+#elif EIGEN_HAS_STD_RESULT_OF
 template<typename T> struct result_of {
   typedef typename std::result_of<T>::type type1;
   typedef typename remove_all<type1>::type type;
@@ -296,6 +313,35 @@ template<typename T> struct result_of { };
 struct has_none {int a[1];};
 struct has_std_result_type {int a[2];};
 struct has_tr1_result {int a[3];};
+
+template <typename Func, int SizeOf>
+struct nullary_result_of_select {};
+
+template <typename Func>
+struct nullary_result_of_select<Func, sizeof(has_std_result_type)> {
+  typedef typename Func::result_type type;
+};
+
+template <typename Func>
+struct nullary_result_of_select<Func, sizeof(has_tr1_result)> {
+  typedef typename Func::template result<Func()>::type type;
+};
+
+template <typename Func>
+struct result_of<Func()> {
+  template <typename T>
+  static has_std_result_type testFunctor(T const *,
+                                         typename T::result_type const * = 0);
+  template <typename T>
+  static has_tr1_result testFunctor(
+      T const *, typename T::template result<T()>::type const * = 0);
+  static has_none testFunctor(...);
+
+  // note that the following indirection is needed for gcc-3.3
+  enum { FunctorType = sizeof(testFunctor(static_cast<Func *>(0))) };
+  typedef typename nullary_result_of_select<Func, FunctorType>::type type;
+};
+
 
 template<typename Func, typename ArgType, int SizeOf=sizeof(has_none)>
 struct unary_result_of_select {typedef typename internal::remove_all<ArgType>::type type;};
@@ -366,6 +412,48 @@ struct result_of<Func(ArgType0,ArgType1,ArgType2)> {
     enum {FunctorType = sizeof(testFunctor(static_cast<Func*>(0)))};
     typedef typename ternary_result_of_select<Func, ArgType0, ArgType1, ArgType2, FunctorType>::type type;
 };
+
+#endif
+
+#if EIGEN_HAS_STD_INVOKE_RESULT
+template <typename F, typename... ArgTypes>
+struct invoke_result {
+  typedef typename std::invoke_result<F, ArgTypes...>::type type1;
+  typedef typename remove_all<type1>::type type;
+};
+#elif EIGEN_HAS_CXX11
+template <typename F, typename... ArgTypes>
+struct invoke_result {
+  typedef typename result_of<F(ArgTypes...)>::type type1;
+  typedef typename remove_all<type1>::type type;
+};
+#else
+template <typename F, typename ArgType0 = void, typename ArgType1 = void,
+          typename ArgType2 = void>
+struct invoke_result {
+  typedef typename result_of<F(ArgType0, ArgType1, ArgType2)>::type type1;
+  typedef typename remove_all<type1>::type type;
+};
+
+template <typename F>
+struct invoke_result<F, void, void, void> {
+  typedef typename result_of<F()>::type type1;
+  typedef typename remove_all<type1>::type type;
+};
+
+template <typename F, typename ArgType0>
+struct invoke_result<F, ArgType0, void, void> {
+  typedef typename result_of<F(ArgType0)>::type type1;
+  typedef typename remove_all<type1>::type type;
+};
+
+template <typename F, typename ArgType0, typename ArgType1>
+struct invoke_result<F, ArgType0, ArgType1, void> {
+  typedef typename result_of<F(ArgType0, ArgType1)>::type type1;
+  typedef typename remove_all<type1>::type type;
+};
+
+
 #endif
 
 struct meta_yes { char a[1]; };


### PR DESCRIPTION
When building an internal private repository with c++17/c++20 and llvm20, build fails because unary_negate and binary_negate are not part of the standard or deprecated: https://en.cppreference.com/w/cpp/utility/functional/unary_negate.html 

Also, result_of is also removed.

Fix already exists in eigen repo:
https://gitlab.com/libeigen/eigen/-/commit/3fb42ff7b27822e7f2a948528a5a5a77e3ae7f84
https://gitlab.com/libeigen/eigen/-/commit/a31effc3bca2f0924752caeebfd6f61f7edf9a43