### PR TITLE
Add mkl BUILD files and fix module version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "eigen",
-    version = "3.3.1.swiftnav",
+    version = "3.3.swiftnav.1",
     compatibility_level = 1,
 )
 
@@ -12,4 +12,3 @@ bazel_dep(name = "rules_swiftnav", version = "0.1.0")
 # Use repo extension to provide MKL dependencies via http_archive
 mkl_ext = use_extension("//extensions:mkl_extension.bzl", "mkl_extension")
 use_repo(mkl_ext, "mkl", "mkl_headers")
-

--- a/extensions/mkl.BUILD
+++ b/extensions/mkl.BUILD
@@ -1,0 +1,56 @@
+# Copyright (C) 2023 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
+
+cc_import(
+    name = "libmkl_core",
+    static_library = "libmkl_core.a",
+    visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "libmkl_intel_lp64",
+    static_library = "libmkl_intel_lp64.a",
+    visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "libmkl_gnu_thread",
+    static_library = "libmkl_gnu_thread.a",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mkl",
+    srcs = [
+        "@mkl//:libmkl_core.a",
+        "@mkl//:libmkl_gnu_thread.a",
+        "@mkl//:libmkl_intel_lp64.a",
+    ],
+    copts = ["-fopenmp"],
+    linkopts = [
+        "-Wl,--start-group",
+        "$(location @mkl//:libmkl_intel_lp64.a)",
+        "$(location @mkl//:libmkl_core.a)",
+        "$(location @mkl//:libmkl_gnu_thread.a)",
+        "-Wl,--end-group",
+        "-l:libgomp.a",
+    ],
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":libmkl_core",
+        ":libmkl_gnu_thread",
+        ":libmkl_intel_lp64",
+        "@mkl_headers",
+    ],
+    alwayslink = 1,
+)

--- a/extensions/mkl_extension.bzl
+++ b/extensions/mkl_extension.bzl
@@ -4,21 +4,21 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _mkl_extension_impl(module_ctx):
     """Implementation of the MKL extension."""
-    
+
     # Define MKL headers
     http_archive(
         name = "mkl_headers",
-        build_file = "@rules_swiftnav//third_party:mkl_headers.BUILD",
+        build_file = ":mkl_headers.BUILD",
         sha256 = "b24d12a8e18ba23de5c659a33fb184a7ac6019d4b159e78f628d7c8de225f77a",
         urls = [
             "https://swiftnav-public-mkl-sharedlibs.s3.us-west-2.amazonaws.com/mkl-include-2023.1.0-intel_46342.tar.bz2",
         ],
     )
-    
+
     # Define MKL static libraries
     http_archive(
         name = "mkl",
-        build_file = "@rules_swiftnav//third_party:mkl.BUILD",
+        build_file = ":mkl.BUILD",
         sha256 = "c63adbfdbdc7c4992384a2d89cd62211e4a9f8061e3e841af1a269699531cb02",
         strip_prefix = "lib",
         urls = [

--- a/extensions/mkl_headers.BUILD
+++ b/extensions/mkl_headers.BUILD
@@ -1,0 +1,22 @@
+# Copyright (C) 2023 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "mkl_headers",
+    hdrs = glob(["include/*.h"]),
+    includes = ["include"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Take over BUILD files from `rules_swiftnav` and fix module version according to internal naming convention.