### PR TITLE
Use `additional_linker_inputs` in order to be compatible to Bazel 9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.9")
-bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_swiftnav", version = "0.1.0")
 

--- a/extensions/mkl.BUILD
+++ b/extensions/mkl.BUILD
@@ -28,9 +28,20 @@ cc_import(
     visibility = ["//visibility:public"],
 )
 
+# MKL must be linked as a re-scanned archive group so the linker resolves the
+# libraries' circular references while pulling in only the objects actually
+# referenced. The archives are intentionally NOT placed in `srcs`/`deps` and the
+# target is NOT `alwayslink`: with newer rules_cc (Bazel 9) that makes the
+# precompiled archives link with `--whole-archive`, which drags in the
+# distributed-memory cluster FFT wrappers (Dfti*DM) and the MPI wrapper object.
+# Those reference symbols from libmkl_cdft_core.a and the BLACS/MPI libraries
+# that this single-node link does not include, producing undefined-symbol link
+# errors (e.g. mkl_cdft_*, DftiComputeForwardDM, MKLMPI_Get_wrappers). The
+# `--start-group` link line below is Intel's documented way to link the static
+# MKL libraries.
 cc_library(
     name = "mkl",
-    srcs = [
+    additional_linker_inputs = [
         "@mkl//:libmkl_core.a",
         "@mkl//:libmkl_gnu_thread.a",
         "@mkl//:libmkl_intel_lp64.a",
@@ -47,10 +58,6 @@ cc_library(
     linkstatic = 1,
     visibility = ["//visibility:public"],
     deps = [
-        ":libmkl_core",
-        ":libmkl_gnu_thread",
-        ":libmkl_intel_lp64",
         "@mkl_headers",
     ],
-    alwayslink = 1,
 )


### PR DESCRIPTION
Adapted to make the `mkl` libs compatible to newer versions of Bazel 9/`rules_cc` 